### PR TITLE
Reduced allowed line max length to 100

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,4 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 # editorconfig-tools is unable to ignore longs strings or urls
 max_line_length = null
+end_of_line = lf

--- a/packages/eslint-config-samsao-base/rules/style.js
+++ b/packages/eslint-config-samsao-base/rules/style.js
@@ -9,7 +9,7 @@ module.exports = {
       SwitchCase: 1,
       VariableDeclarator: { var: 2, let: 2, const: 3 },
     }],
-    'max-len': ['error', 120],
+    'max-len': ['error', 100],
     'newline-per-chained-call': ['error', { ignoreChainWithDepth: 3 }],
   },
 };

--- a/packages/eslint-config-samsao-web/.eslintrc
+++ b/packages/eslint-config-samsao-web/.eslintrc
@@ -1,7 +1,7 @@
 {
-  'extends': './index.js',
+  "extends": "./index.js",
 
-  'rules': {
-    'import/no-commonjs': 'off',
-  },
+  "rules": {
+    "import/no-commonjs": "off"
+  }
 }

--- a/packages/eslint-config-samsao-web/package.json
+++ b/packages/eslint-config-samsao-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-samsao-web",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Samsao's ESLint config, for the web",
   "main": "index.js",
   "scripts": {
@@ -44,8 +44,8 @@
     "babel-tape-runner": "^2.0.1",
     "editorconfig-tools": "^0.1.1",
     "eslint": "^3.19.0",
-    "eslint-config-airbnb": "^15.0.0",
-    "eslint-config-airbnb-base": "^11.0.0",
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-config-airbnb-base": "^12.0.0",
     "eslint-config-samsao-base": "^1.0.0",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-filenames": "^1.1.0",

--- a/packages/eslint-config-samsao-web/rules/react.js
+++ b/packages/eslint-config-samsao-web/rules/react.js
@@ -11,5 +11,11 @@ module.exports = {
     'react/no-redundant-should-component-update': 'error',
     'react/prefer-stateless-function': ['error', { ignorePureComponents: true }],
     'react/sort-comp': 'off',
+    'react/no-unused-state': 'off',
+    'react/boolean-prop-naming': ['off', {
+      propTypeNames: ['bool', 'mutuallyExclusiveTrueProps'],
+      rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+',
+    }],
+    'react/no-typos': 'off',
   },
 };


### PR DESCRIPTION
As discussed in one of our NinJS guild meeting, the allowed max length
for a single line of code is now 100 characters.

See the issue here: https://github.com/samsao/guilds/issues/106

Additionally, I added some rules that were not defined in our config but
were new to the eslint-react-plugin. I tried to update the airbnb config
we use before doing so but the changes aren't published yet. (The last
npm publish was two months ago and the changes to add the rules were
commited a month ago). We need to keep an eye on the next
eslint-config-airbnb release.